### PR TITLE
Updated libraries version for avoiding import problem

### DIFF
--- a/api_01/requirements.txt
+++ b/api_01/requirements.txt
@@ -1,3 +1,3 @@
-flask==1.1.1
-requests
-py_zipkin==0.20.0
+flask==2.1.2
+requests==2.28.0
+py_zipkin==1.0.0

--- a/api_02/requirements.txt
+++ b/api_02/requirements.txt
@@ -1,3 +1,3 @@
-flask==1.1.1
-requests
-py_zipkin==0.20.0
+flask==2.1.2
+requests==2.28.0
+py_zipkin==1.0.0

--- a/api_03/requirements.txt
+++ b/api_03/requirements.txt
@@ -1,3 +1,3 @@
-flask==1.1.1
-requests
-py_zipkin
+flask==2.1.2
+requests==2.28.0
+py_zipkin==1.0.0


### PR DESCRIPTION
I am getting such error on previous libs version:
```
Attaching to zipkin, api_02, api_01, api_03
api_01    | Traceback (most recent call last):
api_01    |   File "app.py", line 1, in <module>
api_01    |     from flask import Flask, request
api_01    |   File "/usr/local/lib/python3.7/site-packages/flask/__init__.py", line 14, in <module>
api_01    |     from jinja2 import escape
api_01    | ImportError: cannot import name 'escape' from 'jinja2' (/usr/local/lib/python3.7/site-packages/jinja2/__init__.py)
api_02    | Traceback (most recent call last):
api_02    |   File "app.py", line 1, in <module>
api_02    |     from flask import Flask, request
api_02    |   File "/usr/local/lib/python3.7/site-packages/flask/__init__.py", line 14, in <module>
api_02    |     from jinja2 import escape
api_02    | ImportError: cannot import name 'escape' from 'jinja2' (/usr/local/lib/python3.7/site-packages/jinja2/__init__.py)
api_03    | Traceback (most recent call last):
api_03    |   File "app.py", line 1, in <module>
api_03    |     from flask import Flask, request
api_03    |   File "/usr/local/lib/python3.7/site-packages/flask/__init__.py", line 14, in <module>
api_03    |     from jinja2 import escape
api_03    | ImportError: cannot import name 'escape' from 'jinja2' (/usr/local/lib/python3.7/site-packages/jinja2/__init__.py)
```
That's why I've created this PR.